### PR TITLE
Fix TypeError exception

### DIFF
--- a/viewProviderProxies.py
+++ b/viewProviderProxies.py
@@ -60,7 +60,7 @@ class ImportedPartViewProviderProxy:
         if hasattr(self, 'Object'):
             importedPart = self.Object
         else:
-            return None
+            return []
         #if hasattr(self, 'object_Name'):
         #    importedPart = FreeCAD.ActiveDocument.getObject( self.object_Name )
         #    if importedPart == None:


### PR DESCRIPTION
Hi,
while importing sub assemblies I get a lot of these exceptions:

`<unknown exception traceback><type 'exceptions.TypeError'>: PyCXX: Error creating object of type N2Py7SeqBaseINS_6ObjectEEE from None`

This commit fixes the issue.

Cheers,
Mateusz
