### PR TITLE
Automatic Labels for Constraints

### DIFF
--- a/angleConstraint.py
+++ b/angleConstraint.py
@@ -16,8 +16,8 @@ def parseSelection(selection, objectToUpdate=None):
                if ( planeSelected(s1) or LinearEdgeSelected(s1)) \
                         and ( planeSelected(s2) or LinearEdgeSelected(s2)):
                     validSelection = True
-                    cParms = [ [s1.ObjectName, s1.SubElementNames[0] ],
-                               [s2.ObjectName, s2.SubElementNames[0] ] ]
+                    cParms = [ [s1.ObjectName, s1.SubElementNames[0], s1.Object.Label ],
+                               [s2.ObjectName, s2.SubElementNames[0], s2.Object.Label ] ]
      if not validSelection:
           msg = '''Angle constraint requires a selection of 2 planes or two straight lines, each from different objects.Selection made:
 %s'''  % printSelection(selection)
@@ -41,7 +41,7 @@ def parseSelection(selection, objectToUpdate=None):
           for prop in ["Object1","Object2","SubElement1","SubElement2","Type"]:
                c.setEditorMode(prop, 1) 
           c.Proxy = ConstraintObjectProxy()
-          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/angleConstraint.svg')
+          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/angleConstraint.svg', True, cParms[1][2], cParms[0][2])
      else:
           debugPrint(2, "redefining %s" % objectToUpdate.Name )
           c = objectToUpdate

--- a/axialConstraint.py
+++ b/axialConstraint.py
@@ -18,8 +18,8 @@ def parseSelection(selection, objectToUpdate=None):
           if s1.ObjectName <> s2.ObjectName:
                if ValidSelection(s1) and ValidSelection(s2):
                     validSelection = True
-                    cParms = [ [s1.ObjectName, s1.SubElementNames[0] ],
-                               [s2.ObjectName, s2.SubElementNames[0] ] ]
+                    cParms = [ [s1.ObjectName, s1.SubElementNames[0], s1.Object.Label ],
+                               [s2.ObjectName, s2.SubElementNames[0], s2.Object.Label ] ]
      if not validSelection:
           msg = '''To add an axial constraint select two cylindrical surfaces or two straight lines, each from a different part. Selection made:
 %s'''  % printSelection(selection)
@@ -45,7 +45,7 @@ def parseSelection(selection, objectToUpdate=None):
                c.setEditorMode(prop, 1) 
 
           c.Proxy = ConstraintObjectProxy()
-          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/axialConstraint.svg')
+          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/axialConstraint.svg', True, cParms[1][2], cParms[0][2])
      else:
           debugPrint(2, "redefining %s" % objectToUpdate.Name )
           c = objectToUpdate

--- a/circularEdgeConstraint.py
+++ b/circularEdgeConstraint.py
@@ -14,8 +14,8 @@ def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lo
         if s1.ObjectName <> s2.ObjectName:
             if CircularEdgeSelected(s1) and CircularEdgeSelected(s2):
                 validSelection = True
-                cParms = [ [s1.ObjectName, s1.SubElementNames[0] ],
-                           [s2.ObjectName, s2.SubElementNames[0] ] ]
+                cParms = [ [s1.ObjectName, s1.SubElementNames[0], s1.Object.Label ],
+                           [s2.ObjectName, s2.SubElementNames[0], s2.Object.Label ] ]
 
     if not validSelection:
           msg = '''To add a circular edge constraint select two circular edges, each from a different part. Selection made:
@@ -44,7 +44,7 @@ def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lo
             c.setEditorMode(prop, 1) 
         
         c.Proxy = ConstraintObjectProxy()
-        c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/circularEdgeConstraint.svg')
+        c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/circularEdgeConstraint.svg', True, cParms[1][2], cParms[0][2])
     else:
         debugPrint(2, "redefining %s" % objectToUpdate.Name )
         c = objectToUpdate

--- a/planeConstraint.py
+++ b/planeConstraint.py
@@ -21,8 +21,8 @@ def parseSelection(selection, objectToUpdate=None):
                     s2, s1 = s1, s2
                if planeSelected(s1) and (planeSelected(s2) or vertexSelected(s2)):
                     validSelection = True
-                    cParms = [ [s1.ObjectName, s1.SubElementNames[0] ],
-                               [s2.ObjectName, s2.SubElementNames[0] ] ]
+                    cParms = [ [s1.ObjectName, s1.SubElementNames[0], s1.Object.Label ],
+                               [s2.ObjectName, s2.SubElementNames[0], s2.Object.Label ] ]
      if not validSelection:
           msg = '''Plane constraint requires a selection of either
 - 2 planes, or
@@ -34,6 +34,9 @@ Selection made:
           return 
 
      if objectToUpdate == None:
+          extraText, extraOk = QtGui.QInputDialog.getText(QtGui.qApp.activeWindow(), "Axis", "Axis for constraint Label", QtGui.QLineEdit.Normal, "0")
+          if not extraOk:
+               return
           cName = findUnusedObjectName('planeConstraint')
           debugPrint(2, "creating %s" % cName )
           c = FreeCAD.ActiveDocument.addObject("App::FeaturePython", cName)
@@ -51,7 +54,7 @@ Selection made:
           for prop in ["Object1","Object2","SubElement1","SubElement2"]:
                c.setEditorMode(prop, 1) 
           c.Proxy = ConstraintObjectProxy()
-          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/planeConstraint.svg') 
+          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/planeConstraint.svg', True, cParms[1][2], cParms[0][2], extraText) 
      else:
           debugPrint(2, "redefining %s" % objectToUpdate.Name )
           c = objectToUpdate

--- a/sphericalSurfaceConstraint.py
+++ b/sphericalSurfaceConstraint.py
@@ -22,8 +22,8 @@ def parseSelection(selection, objectToUpdate=None):
             if ( vertexSelected(s1) or sphericalSurfaceSelected(s1)) \
                     and ( vertexSelected(s2) or sphericalSurfaceSelected(s2)):
                     validSelection = True
-                    cParms = [ [s1.ObjectName, s1.SubElementNames[0] ],
-                               [s2.ObjectName, s2.SubElementNames[0] ] ]
+                    cParms = [ [s1.ObjectName, s1.SubElementNames[0], s1.Object.Label ],
+                               [s2.ObjectName, s2.SubElementNames[0], s2.Object.Label ] ]
 
     if not validSelection:
           msg = '''To add a spherical surface constraint select two spherical surfaces (or vertexs), each from a different part. Selection made:
@@ -47,7 +47,7 @@ def parseSelection(selection, objectToUpdate=None):
             c.setEditorMode(prop, 1) 
         
         c.Proxy = ConstraintObjectProxy()
-        c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/sphericalSurfaceConstraint.svg')
+        c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/sphericalSurfaceConstraint.svg', True, cParms[1][2], cParms[0][2])
     else:
         debugPrint(2, "redefining %s" % objectToUpdate.Name )
         c = objectToUpdate

--- a/viewProviderProxies.py
+++ b/viewProviderProxies.py
@@ -137,8 +137,11 @@ def create_constraint_mirror( constraintObj, iconPath, origLabel= '', mirrorLabe
     if origLabel == '':
         cMirror.Label = constraintObj.Label + '_'
     else:
-        cMirror.Label = constraintObj.Label + '__' + mirrorLabel + '__' + extraLabel
-        constraintObj.Label = constraintObj.Label + '__' + origLabel + '__' + extraLabel
+        cMirror.Label = constraintObj.Label + '__' + mirrorLabel
+        constraintObj.Label = constraintObj.Label + '__' + origLabel
+        if extraLabel != '':
+             cMirror.Label += '__' + extraLabel
+             constraintObj.Label += '__' + extraLabel
     for pName in constraintObj.PropertiesList:
         if constraintObj.getGroupOfProperty( pName ) == 'ConstraintInfo':
             #if constraintObj.getTypeIdOfProperty( pName ) == 'App::PropertyEnumeration':

--- a/viewProviderProxies.py
+++ b/viewProviderProxies.py
@@ -80,7 +80,7 @@ class ImportedPartViewProviderProxy:
     
 
 class ConstraintViewProviderProxy:
-    def __init__( self, constraintObj, iconPath, createMirror=True ):
+    def __init__( self, constraintObj, iconPath, createMirror=True, origLabel = '', mirrorLabel = '', extraLabel = '' ):
         self.iconPath = iconPath
         self.constraintObj_name = constraintObj.Name
         constraintObj.purgeTouched()
@@ -89,7 +89,7 @@ class ConstraintViewProviderProxy:
             part2 = constraintObj.Document.getObject( constraintObj.Object2 )
             if hasattr( getattr(part1.ViewObject,'Proxy',None),'claimChildren') \
                or hasattr( getattr(part2.ViewObject,'Proxy',None),'claimChildren'):
-                self.mirror_name = create_constraint_mirror(  constraintObj, iconPath )
+                self.mirror_name = create_constraint_mirror(  constraintObj, iconPath, origLabel, mirrorLabel, extraLabel )
         
     def getIcon(self):
         return self.iconPath
@@ -130,11 +130,15 @@ class ConstraintMirrorViewProviderProxy( ConstraintViewProviderProxy ):
         vobj.addDisplayMode( coin.SoGroup(),"Standard" )
 
 
-def create_constraint_mirror( constraintObj, iconPath ):
+def create_constraint_mirror( constraintObj, iconPath, origLabel= '', mirrorLabel='', extraLabel = '' ):
     #FreeCAD.Console.PrintMessage("creating constraint mirror\n")
     cName = constraintObj.Name + '_mirror'
     cMirror =  constraintObj.Document.addObject("App::FeaturePython", cName)
-    cMirror.Label = constraintObj.Label + '_'
+    if origLabel == '':
+        cMirror.Label = constraintObj.Label + '_'
+    else:
+        cMirror.Label = constraintObj.Label + '__' + mirrorLabel + '__' + extraLabel
+        constraintObj.Label = constraintObj.Label + '__' + origLabel + '__' + extraLabel
     for pName in constraintObj.PropertiesList:
         if constraintObj.getGroupOfProperty( pName ) == 'ConstraintInfo':
             #if constraintObj.getTypeIdOfProperty( pName ) == 'App::PropertyEnumeration':


### PR DESCRIPTION
Assigns automatic labels to constraints, using the format
"constraintNameXY__ObjectZLabel", where "constraintNameXY" is the
classical constraint name as assigned until now, and "ObjectZ" is the
object referenced by the constaint, respecting the object that this
constraint belongs to. This allows to quickly identify the relation
between objects. The plane constraint asks for an "axis name" on its
definition, so "x", "y" or "z" can be written, being it added at the end of the 
constraint label, so if we have more than one constraint in an object
referring to the same other object, we can easily know which axis is
affected by each one.
