### PR TITLE
Updated obsolete API: QtGui.qApp.activeWindow() to QtGui.QApplication…

### DIFF
--- a/angleConstraint.py
+++ b/angleConstraint.py
@@ -24,8 +24,8 @@ def parseSelection(selection, objectToUpdate=None):
      if not validSelection:
           msg = '''Angle constraint requires a selection of 2 planes or two straight lines/axis, each from different objects.Selection made:
 %s'''  % printSelection(selection)
-          QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", msg)
-          return 
+          QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", msg)
+          return
 
      if objectToUpdate is None:
           cName = findUnusedObjectName('angleConstraint')
@@ -42,7 +42,7 @@ def parseSelection(selection, objectToUpdate=None):
           c.Object2 = cParms[1][0]
           c.SubElement2 = cParms[1][1]
           for prop in ["Object1","Object2","SubElement1","SubElement2","Type"]:
-               c.setEditorMode(prop, 1) 
+               c.setEditorMode(prop, 1)
           c.Proxy = ConstraintObjectProxy()
           c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/angleConstraint.svg', True, cParms[1][2], cParms[0][2])
      else:
@@ -55,8 +55,8 @@ def parseSelection(selection, objectToUpdate=None):
           updateObjectProperties(c)
      constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
      with open(constraintFile, 'w') as outfile:
-          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')        
-          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')        
+          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')
+          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')
      constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
      #print constraints
      if len(constraints) > 0:
@@ -65,15 +65,15 @@ def parseSelection(selection, objectToUpdate=None):
               with open(constraintFile, 'a') as outfile:
                   lastConstraintAdded = constraints[-1]
                   outfile.write(make_string(lastConstraintAdded.Name)+'\n')
-     
+
      c.purgeTouched()
      c.Proxy.callSolveConstraints()
      repair_tree_view()
-         
+
 
 selection_text = '''Selection options:
   - plane surface
-  - edge 
+  - edge
   - axis of plane selected'''
 
 class AngleConstraintCommand:
@@ -84,20 +84,20 @@ class AngleConstraintCommand:
                parseSelection( selection )
           else:
                FreeCADGui.Selection.clearSelection()
-               ConstraintSelectionObserver( 
-                    PlaneSelectionGate(), 
+               ConstraintSelectionObserver(
+                    PlaneSelectionGate(),
                     parseSelection,
-                    taskDialog_title ='add angular constraint', 
-                    taskDialog_iconPath = self.GetResources()['Pixmap'], 
+                    taskDialog_title ='add angular constraint',
+                    taskDialog_iconPath = self.GetResources()['Pixmap'],
                     taskDialog_text = selection_text )
-               
-     def GetResources(self): 
+
+     def GetResources(self):
           msg = 'Create an angular constraint between two planes'
           return {
-               'Pixmap' : ':/assembly2/icons/angleConstraint.svg', 
-               'MenuText': msg, 
+               'Pixmap' : ':/assembly2/icons/angleConstraint.svg',
+               'MenuText': msg,
                'ToolTip': msg,
-               } 
+               }
 
 FreeCADGui.addCommand('addAngleConstraint', AngleConstraintCommand())
 
@@ -107,16 +107,16 @@ class RedefineConstraintCommand:
         self.constObject = FreeCADGui.Selection.getSelectionEx()[0].Object
         debugPrint(3,'redefining %s' % self.constObject.Name)
         FreeCADGui.Selection.clearSelection()
-        ConstraintSelectionObserver( 
-             PlaneSelectionGate(), 
+        ConstraintSelectionObserver(
+             PlaneSelectionGate(),
              self.UpdateConstraint,
-             taskDialog_title ='redefine angular constraint', 
-             taskDialog_iconPath = ':/assembly2/icons/angleConstraint.svg', 
+             taskDialog_title ='redefine angular constraint',
+             taskDialog_iconPath = ':/assembly2/icons/angleConstraint.svg',
              taskDialog_text = selection_text )
 
     def UpdateConstraint(self, selection):
         parseSelection( selection, self.constObject)
 
-    def GetResources(self): 
-        return { 'MenuText': 'Redefine' } 
+    def GetResources(self):
+        return { 'MenuText': 'Redefine' }
 FreeCADGui.addCommand('redefineAngleConstraint', RedefineConstraintCommand())

--- a/animate_constraint.py
+++ b/animate_constraint.py
@@ -18,14 +18,14 @@ class AnimateConstraint_Command:
         constraint_to_animate = selection[0]
         if not 'ConstraintInfo' in constraint_to_animate.Content: #then mirror selected
             constraint_to_animate = FreeCAD.ActiveDocument.getObject( constraint_to_animate.ViewObject.Proxy.constraintObj_name )
-            #return 
+            #return
         self.taskPanel = AnimateConstraint_TaskPanel( constraint_to_animate  )
         FreeCADGui.Control.showDialog( self.taskPanel )
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'MenuText': 'Animate', 
+            'MenuText': 'Animate',
             'ToolTip':  'Animate constraint'
-            } 
+            }
 FreeCADGui.addCommand( 'assemly2_animate_constraint', AnimateConstraint_Command() )
 
 class AnimateConstraint_TaskPanel:
@@ -78,8 +78,8 @@ class AnimateConstraint_Form( QtGui.QWidget):
         self.button_generate_animiation =  QtGui.QPushButton('Generate')
         self.button_generate_animiation.clicked.connect( self.generate_animation )
         vbox.addWidget( self.button_generate_animiation )
-        self.setLayout(vbox)  
-          
+        self.setLayout(vbox)
+
     def generate_animation( self ):
         preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Assembly2")
         org_auto_solve = preferences.GetBool('autoSolveConstraintAttributesChanged', True)
@@ -99,8 +99,8 @@ class AnimateConstraint_Form( QtGui.QWidget):
             self.X = []
             if not hasattr(constraint_to_animate, 'a'):
                 constraint_to_animate.addProperty(
-                    {'angle_between_planes':'App::PropertyAngle', 'plane':'App::PropertyDistance', 'circularEdge':'App::PropertyDistance'}[ constraint_to_animate.Type ], 
-                    'a', 
+                    {'angle_between_planes':'App::PropertyAngle', 'plane':'App::PropertyDistance', 'circularEdge':'App::PropertyDistance'}[ constraint_to_animate.Type ],
+                    'a',
                     "animationParameters"
                     )
                 constraint_to_animate.setEditorMode( 'a', 2)
@@ -177,7 +177,7 @@ class AnimateConstraint_Form( QtGui.QWidget):
     def slider_moved( self, position ):
         try:
             dt = self.constraintAnimator.runningTime
-            p = 1.0 * position / self.animationSlider.maximum() 
+            p = 1.0 * position / self.animationSlider.maximum()
             if not self.constraintAnimator.playing():
                 self.constraintAnimator.showAt( p*dt )
             else:
@@ -206,7 +206,7 @@ class ConstraintAnimator:
         return frame
 
     def play( self, speed, renderFrameHook=None, tick = 20 ):
-        self.timer_speed = speed 
+        self.timer_speed = speed
         self.timer_t_start = time.time()
         self.renderFrameHook = renderFrameHook
         self.timer.start( tick )
@@ -216,7 +216,7 @@ class ConstraintAnimator:
 
     def stop( self ):
         self.timer.stop()
-        
+
     def jumpTo( self, t ):
         self.timer_t_start = time.time() - t/self.timer_speed
 
@@ -260,7 +260,7 @@ class InfoButton( QtGui.QPushButton ):
         self.setMaximumWidth( 12 )
         self.clicked.connect( self.clickFun )
     def clickFun( self ):
-        QtGui.QMessageBox.information( QtGui.qApp.activeWindow(), 'Info', self.info_text ) 
+        QtGui.QMessageBox.information( QtGui.QApplication.activeWindow(), 'Info', self.info_text )
 
 
 class RealParemeter:
@@ -419,18 +419,18 @@ def spline_interp( P, X, n_per_seg ):
     https://en.wikipedia.org/wiki/Cubic_Hermite_spline
     implemented here to assembly2 independent from SciPy
 
-    p ( x ) = h_00 ( t ) p_k + h_10 ( t ) ( x_{k+1} - x_k ) m_k + h_01 ( t ) p_{k + 1} + h_11 ( t ) ( x_{k+1} - x_k ) m_{k+1} . 
+    p ( x ) = h_00 ( t ) p_k + h_10 ( t ) ( x_{k+1} - x_k ) m_k + h_01 ( t ) p_{k + 1} + h_11 ( t ) ( x_{k+1} - x_k ) m_{k+1} .
 
-    with 
+    with
        m = the tangent
        t = ( x - x k ) / ( x k + 1 - x k )
        h_00 =   2 t**3 - 3 t**2       + 1
        h_10 =     t**3 - 2 t**2 + t
-       h_01 = - 2 t**3 + 3 t**2 
-       h_11 =     t**3 -   t**2 
+       h_01 = - 2 t**3 + 3 t**2
+       h_11 =     t**3 -   t**2
 
     natural spline 0,1st, and 2nd order continous, with 2 derivative being 0 and ends
-    
+
     Catmull-Rom spline is obtained, being a special case of a cardinal spline. This assumes uniform parameter spacing.
         m k = ( p_{k+1} - p_{k-1} )/ (t_{k+1} - t_{k-1} )
     '''
@@ -450,8 +450,8 @@ def spline_interp( P, X, n_per_seg ):
             for t in t_int:
                 h_00 =   2*t**3 - 3*t**2       + 1
                 h_10 =     t**3 - 2*t**2 + t
-                h_01 =  -2*t**3 + 3*t**2 
-                h_11 =     t**3 -   t**2 
+                h_01 =  -2*t**3 + 3*t**2
+                h_11 =     t**3 -   t**2
                 p_int.append( h_00*P[k][j] + h_10*dx*m[k] + h_01*P[k+1][j] + h_11*dx*m[k+1])
         P_int[:,j] = p_int
     return P_int
@@ -479,4 +479,3 @@ if __name__ == "__main__":
     pyplot.plot( P_linear[:,0], P_linear[:,1], '--g' )
     pyplot.plot( [p[0] for p in P], [p[1] for p in P], 'go' )
     pyplot.show()
-    

--- a/assembly2solver.py
+++ b/assembly2solver.py
@@ -6,7 +6,7 @@ Notes regarding the assembly constraints problem.
 
 Approach followed is therefore, for the case of adding a constraint
   1. first try solve problem by moving&rotating one part only, if this fails then
-  2. solve entire constraint system by moving&rotating all non-fixed objects 
+  2. solve entire constraint system by moving&rotating all non-fixed objects
 
 '''
 
@@ -34,21 +34,21 @@ def constraintsObjectsAllExist( doc ):
             if not (obj.Object1 in objectNames and obj.Object2 in objectNames):
                 flags = QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.Abort
                 message = "%s is refering to an object no longer in the assembly. Delete constraint? otherwise abort solving." % obj.Name
-                response = QtGui.QMessageBox.critical(QtGui.qApp.activeWindow(), "Broken Constraint", message, flags )
+                response = QtGui.QMessageBox.critical(QtGui.QApplication.activeWindow(), "Broken Constraint", message, flags )
                 if response == QtGui.QMessageBox.Yes:
                     FreeCAD.Console.PrintError("removing constraint %s" % obj.Name)
                     doc.removeObject(obj.Name)
                 else:
                     missingObject = obj.Object2 if obj.Object1 in objectNames else obj.Object1
                     FreeCAD.Console.PrintError("aborted solving constraints due to %s refering the non-existent object %s" % (obj.Name, missingObject))
-                    return False            
+                    return False
     return True
-    
+
 def findBaseObject( doc, objectNames  ):
     debugPrint( 4,'solveConstraints: searching for fixed object to begin solving constraints from.' )
     fixed = [ getattr( doc.getObject( name ), 'fixedPosition', False ) for name in objectNames ]
     if sum(fixed) > 0:
-        return objectNames[ fixed.index(True) ]        
+        return objectNames[ fixed.index(True) ]
     if sum(fixed) == 0:
         debugPrint( 1, 'It is recommended that the assembly 2 module is used with parts imported using the assembly 2 module.')
         debugPrint( 1, 'This allows for part updating, parts list support, object copying (shift + assembly2 move) and also tells the solver which objects to treat as fixed.')
@@ -74,7 +74,7 @@ def solveConstraints( doc, showFailureErrorDialog=True, printErrors=True, cache=
     debugPrint(3,' variableManager.X0 %s' % variableManager.X0 )
     constraintSystem = FixedObjectSystem( variableManager, findBaseObject(doc, objectNames) )
     debugPrint(4, 'solveConstraints base system: %s' % constraintSystem.str() )
-    
+
 
     solved = True
     if cache != None:
@@ -138,14 +138,14 @@ def solveConstraints( doc, showFailureErrorDialog=True, printErrors=True, cache=
         debugPrint(2,'Constraint system solved in %2.2fs; resulting system has %i degrees-of-freedom' % (time.time()-T_start, len( constraintSystem.degreesOfFreedom)))
     elif showFailureErrorDialog and  QtGui.qApp != None: #i.e. GUI active
         # http://www.blog.pythonlibrary.org/2013/04/16/pyside-standard-dialogs-and-message-boxes/
-        flags = QtGui.QMessageBox.StandardButton.Yes 
+        flags = QtGui.QMessageBox.StandardButton.Yes
         flags |= QtGui.QMessageBox.StandardButton.No
         #flags |= QtGui.QMessageBox.Ignore
         message = """The assembly2 solver failed to satisfy the constraint "%s".
 
 possible causes
-  - impossible/contridictorary constraints have be specified, or  
-  - the contraint problem is too difficult for the solver, or 
+  - impossible/contridictorary constraints have be specified, or
+  - the contraint problem is too difficult for the solver, or
   - a bug in the assembly 2 workbench
 
 potential solutions
@@ -154,7 +154,7 @@ potential solutions
 
 Delete constraint "%s"?
 """ % (constraintObj.Name, constraintObj.Name)
-        response = QtGui.QMessageBox.critical(QtGui.qApp.activeWindow(), "Solver Failure!", message, flags)
+        response = QtGui.QMessageBox.critical(QtGui.QApplication.activeWindow(), "Solver Failure!", message, flags)
         if response == QtGui.QMessageBox.Yes:
             removeConstraint( constraintObj )
         #elif response == QtGui.QMessageBox.Ignore:
@@ -170,12 +170,12 @@ class Assembly2SolveConstraintsCommand:
         else:
             solverCache = None
         solveConstraints( FreeCAD.ActiveDocument, cache = solverCache )
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : ':/assembly2/icons/assembly2SolveConstraints.svg', 
-            'MenuText': 'Solve Assembly 2 constraints', 
+            'Pixmap' : ':/assembly2/icons/assembly2SolveConstraints.svg',
+            'MenuText': 'Solve Assembly 2 constraints',
             'ToolTip': 'Solve Assembly 2 constraints'
-            } 
+            }
 
 FreeCADGui.addCommand('assembly2SolveConstraints', Assembly2SolveConstraintsCommand())
 
@@ -202,7 +202,7 @@ if __name__ == '__main__':
     t_solver = 0
     t_cache = 0
     t_start = time.time()
-    testFiles = sorted(glob.glob('tests/*.fcstd')) 
+    testFiles = sorted(glob.glob('tests/*.fcstd'))
     if args.lastTestCaseOnly:
         testFiles = testFiles[-1:]
     for testFile in testFiles:
@@ -220,7 +220,7 @@ if __name__ == '__main__':
             solverCache.debugMode = 1
             constraintSystem = solveConstraints( doc, cache=solverCache )
             solverCache.debugMode = 0
-            t_cache = t_cache  + time.time() - t_start_cache 
+            t_cache = t_cache  + time.time() - t_start_cache
             constraintSystem.update()
         print('\n\n\n')
     print('All %i tests passed:' % len(testFiles) )

--- a/axialConstraint.py
+++ b/axialConstraint.py
@@ -28,8 +28,8 @@ def parseSelection(selection, objectToUpdate=None):
      if not validSelection:
           msg = '''To add an axial constraint select two cylindrical surfaces or two straight lines, each from a different part. Selection made:
 %s'''  % printSelection(selection)
-          QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", msg)
-          return 
+          QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", msg)
+          return
 
      if objectToUpdate == None:
           cName = findUnusedObjectName('axialConstraint')
@@ -40,14 +40,14 @@ def parseSelection(selection, objectToUpdate=None):
           c.addProperty("App::PropertyString","SubElement1","ConstraintInfo").SubElement1 = cParms[0][1]
           c.addProperty("App::PropertyString","Object2","ConstraintInfo").Object2 = cParms[1][0]
           c.addProperty("App::PropertyString","SubElement2","ConstraintInfo").SubElement2 = cParms[1][1]
-     
+
           c.addProperty("App::PropertyEnumeration","directionConstraint", "ConstraintInfo")
           c.directionConstraint = ["none","aligned","opposed"]
           c.addProperty("App::PropertyBool","lockRotation","ConstraintInfo")
-                         
+
           c.setEditorMode('Type',1)
           for prop in ["Object1","Object2","SubElement1","SubElement2"]:
-               c.setEditorMode(prop, 1) 
+               c.setEditorMode(prop, 1)
 
           c.Proxy = ConstraintObjectProxy()
           c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/axialConstraint.svg', True, cParms[1][2], cParms[0][2])
@@ -61,8 +61,8 @@ def parseSelection(selection, objectToUpdate=None):
           updateObjectProperties(c)
      constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
      with open(constraintFile, 'w') as outfile:
-          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')        
-          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')        
+          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')
+          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')
      constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
      #print constraints
      if len(constraints) > 0:
@@ -78,7 +78,7 @@ def parseSelection(selection, objectToUpdate=None):
 
 selection_text = '''Selection options:
   - cylindrical surface
-  - edge 
+  - edge
   - face '''
 
 class AxialConstraintCommand:
@@ -89,19 +89,19 @@ class AxialConstraintCommand:
                parseSelection( selection )
           else:
                FreeCADGui.Selection.clearSelection()
-               ConstraintSelectionObserver( 
-                    AxialSelectionGate(), 
+               ConstraintSelectionObserver(
+                    AxialSelectionGate(),
                     parseSelection,
-                    taskDialog_title ='add axial constraint', 
-                    taskDialog_iconPath = self.GetResources()['Pixmap'], 
+                    taskDialog_title ='add axial constraint',
+                    taskDialog_iconPath = self.GetResources()['Pixmap'],
                     taskDialog_text = selection_text
                     )
-     def GetResources(self): 
+     def GetResources(self):
           return {
-               'Pixmap' : ':/assembly2/icons/axialConstraint.svg', 
-               'MenuText': 'Add axial constraint', 
+               'Pixmap' : ':/assembly2/icons/axialConstraint.svg',
+               'MenuText': 'Add axial constraint',
                'ToolTip': 'Add an axial constraint between two objects'
-               } 
+               }
 
 FreeCADGui.addCommand('addAxialConstraint', AxialConstraintCommand())
 
@@ -110,19 +110,19 @@ class RedefineConstraintCommand:
         self.constObject = FreeCADGui.Selection.getSelectionEx()[0].Object
         debugPrint(3,'redefining %s' % self.constObject.Name)
         FreeCADGui.Selection.clearSelection()
-        ConstraintSelectionObserver( 
-             AxialSelectionGate(), 
+        ConstraintSelectionObserver(
+             AxialSelectionGate(),
              self.UpdateConstraint,
-             taskDialog_title ='redefine axial constraint', 
-             taskDialog_iconPath = ':/assembly2/icons/axialConstraint.svg', 
+             taskDialog_title ='redefine axial constraint',
+             taskDialog_iconPath = ':/assembly2/icons/axialConstraint.svg',
              taskDialog_text = selection_text
              )
         #
-        #if wb_globals.has_key('selectionObserver'): 
+        #if wb_globals.has_key('selectionObserver'):
         #    wb_globals['selectionObserver'].stopSelectionObservation()
         #wb_globals['selectionObserver'] =  ConstraintSelectionObserver( AxialSelectionGate(), self.UpdateConstraint  )
     def UpdateConstraint(self, selection):
         parseSelection( selection, self.constObject)
-    def GetResources(self): 
-        return { 'MenuText': 'Redefine' } 
+    def GetResources(self):
+        return { 'MenuText': 'Redefine' }
 FreeCADGui.addCommand('redefineAxialConstraint', RedefineConstraintCommand())

--- a/boltMultipleCircularEdges.py
+++ b/boltMultipleCircularEdges.py
@@ -24,14 +24,14 @@ class boltMultipleCircularEdgesCommand:
             if valid:
                 boltSelection()
             else:
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", 'Select only circular edges')
-    def GetResources(self): 
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", 'Select only circular edges')
+    def GetResources(self):
         msg = 'Bolt multiple circular edges'
         return {
-            'Pixmap' : ':/assembly2/icons/boltMultipleCircularEdges.svg', 
-            'MenuText': msg, 
+            'Pixmap' : ':/assembly2/icons/boltMultipleCircularEdges.svg',
+            'MenuText': msg,
             'ToolTip': msg
-            } 
+            }
 
 FreeCADGui.addCommand('boltMultipleCircularEdges', boltMultipleCircularEdgesCommand())
 
@@ -40,10 +40,10 @@ class RapidBoltingTaskDialog:
         self.form = RapidBoltingForm('''Instructions:
 
 1) select mating edge on Bolt
-2) add to the Selection the edges 
+2) add to the Selection the edges
 to which the bolt is to be mated
 3) press Ok ''' )
-        self.form.setWindowTitle( 'Bolt multiple circular edges' )    
+        self.form.setWindowTitle( 'Bolt multiple circular edges' )
         self.form.setWindowIcon( QtGui.QIcon( ':/assembly2/icons/boltMultipleCircularEdges.svg' ) )
     def reject(self):
         FreeCADGui.Selection.removeSelectionGate()
@@ -52,10 +52,10 @@ to which the bolt is to be mated
         FreeCADGui.Selection.removeSelectionGate()
         FreeCADGui.Control.closeDialog()
         boltSelection()
-class RapidBoltingForm(QtGui.QWidget):    
+class RapidBoltingForm(QtGui.QWidget):
     def __init__(self, textLines ):
         super(RapidBoltingForm, self).__init__()
-        self.textLines = textLines 
+        self.textLines = textLines
         self.initUI()
     def initUI(self):
         vbox = QtGui.QVBoxLayout()
@@ -73,7 +73,7 @@ def boltSelection():
     selection = FreeCADGui.Selection.getSelectionEx()
     bolt = selection[0].Object
     bolt_se_name = selection[0].SubElementNames[0]
-    S = [] #edgesToConstrainTo 
+    S = [] #edgesToConstrainTo
     for s in selection[1:]:
         for se_name in s.SubElementNames:
             S.append( SelectionExObject(doc, s.Object, se_name) )
@@ -82,8 +82,8 @@ def boltSelection():
         s1 = SelectionExObject(doc, newBolt, bolt_se_name)
         debugPrint(3,'s1 %s' % [s1, s2])
         parseSelection(
-            [s1, s2 ], 
-            callSolveConstraints= False, lockRotation = True 
+            [s1, s2 ],
+            callSolveConstraints= False, lockRotation = True
             )
     solveConstraints( doc )
     FreeCAD.ActiveDocument.commitTransaction()

--- a/checkAssembly.py
+++ b/checkAssembly.py
@@ -10,7 +10,7 @@ class CheckAssemblyCommand:
         objects = [obj for obj in FreeCAD.ActiveDocument.Objects if hasattr(obj, 'Shape') and obj.Name != 'muxedAssembly']
         n = len(objects)
         no_of_checks = 0.5*(n-1)*(n)
-        moduleVars['progressDialog'] = QtGui.QProgressDialog("Checking assembly", "Cancel", 0, no_of_checks)#, QtGui.qApp.activeWindow()) with parent cancel does not work for some reason
+        moduleVars['progressDialog'] = QtGui.QProgressDialog("Checking assembly", "Cancel", 0, no_of_checks)#, QtGui.QApplication.activeWindow()) with parent cancel does not work for some reason
         p = moduleVars['progressDialog']
         p.setWindowModality(QtCore.Qt.WindowModal)
         p.forceShow()
@@ -38,7 +38,7 @@ class CheckAssemblyCommand:
                     else:
                         debugPrint(3, '    skipping check based on boundBoxesOverlap check')
                     count = count + 1
-                else:            
+                else:
                     break
         debugPrint(3, 'ProgressDialog canceled %s' % p.wasCanceled())
         if not p.wasCanceled():
@@ -51,16 +51,16 @@ class CheckAssemblyCommand:
                 message = "Overlap detected between:\n  - %s" % "  \n  - ".join(overlapMsgs)
                 message = message + '\n\n*overlap.Volume / min( shape1.Volume, shape2.Volume )'
                 FreeCAD.Console.PrintError( message + '\n' )
-                response = QtGui.QMessageBox.critical(QtGui.qApp.activeWindow(), "Assembly Check", message + errorMsg)#, flags)
+                response = QtGui.QMessageBox.critical(QtGui.QApplication.activeWindow(), "Assembly Check", message + errorMsg)#, flags)
             else:
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Assembly Check", "Passed:\n  - No overlap/interferance dectected." + errorMsg)
-    def GetResources(self): 
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Assembly Check", "Passed:\n  - No overlap/interferance dectected." + errorMsg)
+    def GetResources(self):
         msg = 'Check assembly for part overlap/interferance'
         return {
-            'Pixmap' : ':/assembly2/icons/checkAssembly.svg', 
-            'MenuText': msg, 
+            'Pixmap' : ':/assembly2/icons/checkAssembly.svg',
+            'MenuText': msg,
             'ToolTip':  msg
-            } 
+            }
 FreeCADGui.addCommand('assembly2_checkAssembly', CheckAssemblyCommand())
 
 
@@ -73,6 +73,6 @@ def boundBoxesOverlap( shape1, shape2, tol ):
         overlap = box1.common(box2)
     except:
         return True
-    overlap_ratio = overlap.Volume / min( box1.Volume, box2.Volume )  
+    overlap_ratio = overlap.Volume / min( box1.Volume, box2.Volume )
     debugPrint(3, '    boundBoxesOverlap:overlap_ratio %e' % overlap_ratio)
     return overlap_ratio > tol

--- a/circularEdgeConstraint.py
+++ b/circularEdgeConstraint.py
@@ -13,7 +13,7 @@ class CircularEdgeSelectionGate:
 def ValidSelectionFunct(selectionExObj, doc, obj, sub):
      return CircularEdgeSelected( SelectionExObject(doc, obj, sub) )\
          or AxisOfPlaneSelected(selectionExObj)
-         
+
 def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lockRotation = False):
     validSelection = False
     if len(selection) == 2:
@@ -26,29 +26,29 @@ def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lo
     if not validSelection:
           msg = '''To add a circular edge constraint select two circular edges, each from a different part. Selection made:
 %s'''  % printSelection(selection)
-          QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", msg)
-          return 
+          QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", msg)
+          return
 
     if objectToUpdate == None:
         cName = findUnusedObjectName('circularEdgeConstraint')
         debugPrint(2, "creating %s" % cName )
         c = FreeCAD.ActiveDocument.addObject("App::FeaturePython", cName)
-                
+
         c.addProperty("App::PropertyString","Type","ConstraintInfo").Type = 'circularEdge'
         c.addProperty("App::PropertyString","Object1","ConstraintInfo").Object1 = cParms[0][0]
         c.addProperty("App::PropertyString","SubElement1","ConstraintInfo").SubElement1 = cParms[0][1]
         c.addProperty("App::PropertyString","Object2","ConstraintInfo").Object2 = cParms[1][0]
         c.addProperty("App::PropertyString","SubElement2","ConstraintInfo").SubElement2 = cParms[1][1]
-    
+
         c.addProperty("App::PropertyEnumeration","directionConstraint", "ConstraintInfo")
         c.directionConstraint = ["none","aligned","opposed"]
         c.addProperty("App::PropertyDistance","offset","ConstraintInfo")
         c.addProperty("App::PropertyBool","lockRotation","ConstraintInfo").lockRotation = lockRotation
-    
+
         c.setEditorMode('Type',1)
         for prop in ["Object1","Object2","SubElement1","SubElement2"]:
-            c.setEditorMode(prop, 1) 
-        
+            c.setEditorMode(prop, 1)
+
         c.Proxy = ConstraintObjectProxy()
         c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/circularEdgeConstraint.svg', True, cParms[1][2], cParms[0][2])
     else:
@@ -61,8 +61,8 @@ def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lo
         updateObjectProperties(c)
     constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
     with open(constraintFile, 'w') as outfile:
-         outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')        
-         outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')        
+         outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')
+         outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')
     constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
     #print constraints
     if len(constraints) > 0:
@@ -74,12 +74,12 @@ def parseSelection(selection, objectToUpdate=None, callSolveConstraints=True, lo
 
     c.purgeTouched()
     if callSolveConstraints:
-        c.Proxy.callSolveConstraints()  
+        c.Proxy.callSolveConstraints()
         repair_tree_view()
     #FreeCADGui.Selection.clearSelection()
     #FreeCADGui.Selection.addSelection(c)
     return c
-    
+
 
 selection_text = '''Select circular edges or faces'''
 
@@ -90,20 +90,20 @@ class CircularEdgeConstraintCommand:
             parseSelection( selection )
         else:
             FreeCADGui.Selection.clearSelection()
-            ConstraintSelectionObserver( 
-                CircularEdgeSelectionGate(), 
+            ConstraintSelectionObserver(
+                CircularEdgeSelectionGate(),
                 parseSelection,
-                taskDialog_title ='add circular edge constraint', 
-                taskDialog_iconPath = self.GetResources()['Pixmap'], 
+                taskDialog_title ='add circular edge constraint',
+                taskDialog_iconPath = self.GetResources()['Pixmap'],
                 taskDialog_text = selection_text
                 )
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : ':/assembly2/icons/circularEdgeConstraint.svg' , 
-            'MenuText': 'Add circular edge constraint', 
+            'Pixmap' : ':/assembly2/icons/circularEdgeConstraint.svg' ,
+            'MenuText': 'Add circular edge constraint',
             'ToolTip': 'Add a circular edge constraint between two objects'
-            } 
+            }
 
 FreeCADGui.addCommand('addCircularEdgeConstraint', CircularEdgeConstraintCommand())
 
@@ -113,33 +113,33 @@ class RedefineCircularEdgeConstraintCommand:
         self.constObject = FreeCADGui.Selection.getSelectionEx()[0].Object
         debugPrint(3,'redefining %s' % self.constObject.Name)
         FreeCADGui.Selection.clearSelection()
-        ConstraintSelectionObserver( 
-                CircularEdgeSelectionGate(), 
+        ConstraintSelectionObserver(
+                CircularEdgeSelectionGate(),
                 self.UpdateConstraint,
-                taskDialog_title ='redefine circular edge constraint', 
-                taskDialog_iconPath = ':/assembly2/icons/circularEdgeConstraint.svg', 
+                taskDialog_title ='redefine circular edge constraint',
+                taskDialog_iconPath = ':/assembly2/icons/circularEdgeConstraint.svg',
                 taskDialog_text = selection_text
                 )
 
     def UpdateConstraint(self, selection):
         parseSelection( selection, self.constObject)
 
-    def GetResources(self): 
-        return { 'MenuText': 'Redefine' } 
+    def GetResources(self):
+        return { 'MenuText': 'Redefine' }
 FreeCADGui.addCommand('redefineCircularEdgeConstraint', RedefineCircularEdgeConstraintCommand())
 
 
 class FlipLastConstraintsDirectionCommand:
     def Activated(self):
-        constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects 
+        constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects
                         if 'ConstraintInfo' in obj.Content ]
         if len(constraints) == 0:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Flip aborted since no assembly2 constraints in active document.')
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Flip aborted since no assembly2 constraints in active document.')
             return
         lastConstraintAdded = constraints[-1]
         if hasattr( lastConstraintAdded, 'directionConstraint' ):
             if lastConstraintAdded.directionConstraint == "none":
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Flip aborted since direction of the last constraint is unset')
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Flip aborted since direction of the last constraint is unset')
                 return
             if lastConstraintAdded.directionConstraint == "aligned":
                 lastConstraintAdded.directionConstraint = "opposed"
@@ -151,16 +151,16 @@ class FlipLastConstraintsDirectionCommand:
             else:
                 lastConstraintAdded.angle = lastConstraintAdded.angle.Value - 180.0
         else:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Flip aborted since the last constraint added does not have a direction or an angle attribute.')
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Flip aborted since the last constraint added does not have a direction or an angle attribute.')
             return
         FreeCAD.ActiveDocument.recompute()
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : ':/assembly2/icons/flipConstraint.svg' , 
-            'MenuText': "Flip last constraint's direction", 
+            'Pixmap' : ':/assembly2/icons/flipConstraint.svg' ,
+            'MenuText': "Flip last constraint's direction",
             'ToolTip': 'Flip the direction of the last constraint added'
-            } 
+            }
 
 FreeCADGui.addCommand('flipLastConstraintsDirection', FlipLastConstraintsDirectionCommand())
 
@@ -168,10 +168,10 @@ FreeCADGui.addCommand('flipLastConstraintsDirection', FlipLastConstraintsDirecti
 
 class LockRotationOfLastConstraintAddedCommand:
     def Activated(self):
-        constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects 
+        constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects
                         if 'ConstraintInfo' in obj.Content ]
         if len(constraints) == 0:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Set LockRotation=True aborted since no assembly2 constraints in active document.')
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Set LockRotation=True aborted since no assembly2 constraints in active document.')
             return
         lastConstraintAdded = constraints[-1]
         if hasattr( lastConstraintAdded, 'lockRotation' ):
@@ -179,16 +179,16 @@ class LockRotationOfLastConstraintAddedCommand:
                 lastConstraintAdded.lockRotation = True
                 FreeCAD.ActiveDocument.recompute()
             else:
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Information", 'Last constraints LockRotation attribute already set to True.')
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Information", 'Last constraints LockRotation attribute already set to True.')
         else:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Set LockRotation=True aborted since the last constraint added does not the LockRotation attribute.')
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Set LockRotation=True aborted since the last constraint added does not the LockRotation attribute.')
             return
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : ':/assembly2/icons/lockRotation.svg' , 
-            'MenuText': "Set lockRotation->True for the last constraint added", 
+            'Pixmap' : ':/assembly2/icons/lockRotation.svg' ,
+            'MenuText': "Set lockRotation->True for the last constraint added",
             'ToolTip': 'Set lockRotation->True for the last constraint added'
-            } 
+            }
 
 FreeCADGui.addCommand('lockLastConstraintsRotation', LockRotationOfLastConstraintAddedCommand())

--- a/importPart.py
+++ b/importPart.py
@@ -62,11 +62,11 @@ def importPart( filename, partName=None, doc_assembly=None ):
         if len(visibleObjects) != 1:
             if not updateExistingPart:
                 msg = "A part can only be imported from a FreeCAD document with exactly one visible part. Aborting operation"
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Value Error", msg )
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Value Error", msg )
             else:
                 msg = "Error updating part from %s: A part can only be imported from a FreeCAD document with exactly one visible part. Aborting update of %s" % (partName, filename)
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Value Error", msg )
-        #QtGui.QMessageBox.warning( QtGui.qApp.activeWindow(), "Value Error!", msg, QtGui.QMessageBox.StandardButton.Ok )
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Value Error", msg )
+        #QtGui.QMessageBox.warning( QtGui.QApplication.activeWindow(), "Value Error!", msg, QtGui.QMessageBox.StandardButton.Ok )
             return
         obj_to_copy  = visibleObjects[0]
 
@@ -106,7 +106,7 @@ def importPart( filename, partName=None, doc_assembly=None ):
             obj.ViewObject.Transparency = tsp+1
         if tsp == 100:
             obj.ViewObject.Transparency = tsp-1
-        obj.ViewObject.Transparency = tsp   # .Transparency workaround end 
+        obj.ViewObject.Transparency = tsp   # .Transparency workaround end
     obj.Proxy = Proxy_importPart()
     obj.timeLastImport = os.path.getmtime( filename )
     #clean up
@@ -128,13 +128,13 @@ class ImportPartCommand:
             FreeCAD.newDocument()
         view = FreeCADGui.activeDocument().activeView()
         #filename, filetype = QtGui.QFileDialog.getOpenFileName(
-        #    QtGui.qApp.activeWindow(),
+        #    QtGui.QApplication.activeWindow(),
         #    "Select FreeCAD document to import part from",
         #    "",# "" is the default, os.path.dirname(FreeCAD.ActiveDocument.FileName),
         #    "FreeCAD Document (*.fcstd)"
         #    )
         dialog = QtGui.QFileDialog(
-            QtGui.qApp.activeWindow(),
+            QtGui.QApplication.activeWindow(),
             "Select FreeCAD document to import part from"
             )
         dialog.setNameFilter("Supported Formats (*.FCStd *.brep *.brp *.imp *.iges *.igs *.obj *.step *.stp);;All files (*.*)")
@@ -234,7 +234,7 @@ class UpdateImportedPartsCommand:
                                     replacement = newFn
                                     break
                                 reply = QtGui.QMessageBox.question(
-                                    QtGui.qApp.activeWindow(), "%s source file not found" % obj.Name,
+                                    QtGui.QApplication.activeWindow(), "%s source file not found" % obj.Name,
                                     "Unable to find\n  %s \nUse \n  %s\n instead?" % (obj.sourceFile, newFn) ,
                                     QtGui.QMessageBox.Yes | QtGui.QMessageBox.YesToAll | QtGui.QMessageBox.No, QtGui.QMessageBox.Yes)
                                 if reply == QtGui.QMessageBox.Yes:
@@ -250,7 +250,7 @@ class UpdateImportedPartsCommand:
                     if replacement != None:
                         obj.sourceFile = replacement
                     else:
-                        QtGui.QMessageBox.critical(  QtGui.qApp.activeWindow(), "Source file not found", "update of %s aborted!\nUnable to find %s" % (obj.Name, obj.sourceFile) )
+                        QtGui.QMessageBox.critical(  QtGui.QApplication.activeWindow(), "Source file not found", "update of %s aborted!\nUnable to find %s" % (obj.Name, obj.sourceFile) )
                         obj.timeLastImport = 0 #force update if users repairs link
                 if path_rel_to_abs( obj.sourceFile ) is not None:
                     absolutePath = path_rel_to_abs( obj.sourceFile )
@@ -444,7 +444,7 @@ class ForkPartCommand:
         selection = [s for s in FreeCADGui.Selection.getSelection() if s.Document == FreeCAD.ActiveDocument ]
         obj = selection[0]
         filename, filetype = QtGui.QFileDialog.getSaveFileName(
-            QtGui.qApp.activeWindow(),
+            QtGui.QApplication.activeWindow(),
             "Specify the filename for the fork of '%s'" % obj.Label[:obj.Label.find('_import')],
             os.path.dirname(FreeCAD.ActiveDocument.FileName),
             "FreeCAD Document (*.fcstd)"
@@ -457,7 +457,7 @@ class ForkPartCommand:
             obj.sourceFile = filename
             FreeCAD.open(obj.sourceFile)
         else:
-            QtGui.QMessageBox.critical(  QtGui.qApp.activeWindow(), "Bad filename", "Specify a new filename!")
+            QtGui.QMessageBox.critical(  QtGui.QApplication.activeWindow(), "Bad filename", "Specify a new filename!")
 
     def GetResources(self):
         return {
@@ -477,11 +477,11 @@ class DeletePartsConstraints:
                 if part.Name in [ c.Object1, c.Object2 ]:
                     deleteList.append(c)
         if len(deleteList) == 0:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Info", 'No constraints refer to "%s"' % part.Name)
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Info", 'No constraints refer to "%s"' % part.Name)
         else:
             flags = QtGui.QMessageBox.StandardButton.Yes | QtGui.QMessageBox.StandardButton.No
             msg = "Delete %s's constraint(s):\n  - %s?" % ( part.Name, '\n  - '.join( c.Name for c in deleteList))
-            response = QtGui.QMessageBox.critical(QtGui.qApp.activeWindow(), "Delete constraints?", msg, flags )
+            response = QtGui.QMessageBox.critical(QtGui.QApplication.activeWindow(), "Delete constraints?", msg, flags )
             if response == QtGui.QMessageBox.Yes:
                 for c in deleteList:
                     removeConstraint(c)

--- a/partsList.py
+++ b/partsList.py
@@ -43,7 +43,7 @@ def parts_list_clickHandler( x, y ):
 class AddPartsList:
     def Activated(self):
         if not drawing_dimensioning_installed:
-            QtGui.QMessageBox.critical( QtGui.qApp.activeWindow(), 'drawing dimensioning wb required', 'the parts list feature requires the drawing dimensioning wb (https://github.com/hamish2014/FreeCAD_drawing_dimensioning). Release from 12 April 2016 or later required.' )
+            QtGui.QMessageBox.critical( QtGui.QApplication.activeWindow(), 'drawing dimensioning wb required', 'the parts list feature requires the drawing dimensioning wb (https://github.com/hamish2014/FreeCAD_drawing_dimensioning). Release from 12 April 2016 or later required.' )
             return
         V = getDrawingPageGUIVars() #needs to be done before dialog show, else Qt active is dialog and not freecads
         d.activate( V, dialogIconPath= ':/assembly2/icons/partsList.svg')
@@ -58,14 +58,14 @@ class AddPartsList:
         d.taskDialog =  PartsListTaskDialog()
         FreeCADGui.Control.showDialog( d.taskDialog )
         previewDimension.initializePreview( d, table_dd.table_preview, parts_list_clickHandler )
-        
-    def GetResources(self): 
+
+    def GetResources(self):
         tip = 'Create a part list from the objects imported using the assembly 2 workbench'
         return {
-            'Pixmap' : ':/assembly2/icons/partsList.svg' , 
-            'MenuText': tip, 
+            'Pixmap' : ':/assembly2/icons/partsList.svg' ,
+            'MenuText': tip,
             'ToolTip': tip
-            } 
+            }
 FreeCADGui.addCommand('addPartsList', AddPartsList())
 
 
@@ -81,7 +81,7 @@ class PartsListTaskDialog:
                 if hasattr(w, 'valueChanged'):
                     w.valueChanged.connect( self.getValues )
                 if isinstance(w, QtGui.QLineEdit):
-                    w.textChanged.connect( self.getValues ) 
+                    w.textChanged.connect( self.getValues )
         self.form.pushButton_set_as_default.clicked.connect( self.setDefaults )
 
     def setIntialValues(self):
@@ -104,16 +104,16 @@ class PartsListTaskDialog:
                 item.setCheckState( QtCore.Qt.CheckState.Checked )
                 filtersAdded.append( entry.parentDirectory )
         d.partsList.directoryMask = filtersAdded
-        form.listWidget_directoryFilter.itemChanged.connect( self.update_directoryFilter )  
+        form.listWidget_directoryFilter.itemChanged.connect( self.update_directoryFilter )
 
     def setDefaults(self):
         parms = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Assembly2/partsList")
-        form = self.form        
+        form = self.form
         parms.SetFloat('column_part_width',       form.doubleSpinBox_column_part_width.value()       )
         parms.SetFloat('column_sourceFile_width', form.doubleSpinBox_column_sourceFile_width.value() )
         parms.SetFloat('column_quantity_width',   form.doubleSpinBox_column_quantity_width.value()   )
         parms.SetString('column_part_label',      form.lineEdit_column_part_label.text()             )
-        parms.SetString('column_sourceFile_label',form.lineEdit_column_sourceFile_label.text()       ) 
+        parms.SetString('column_sourceFile_label',form.lineEdit_column_sourceFile_label.text()       )
         parms.SetString('column_quantity_label',  form.lineEdit_column_quantity_label.text()         )
         parms.SetFloat('lineWidth',               form.doubleSpinBox_lineWidth.value()               )
         parms.SetFloat('fontSize',                form.doubleSpinBox_fontSize.value()                )
@@ -148,16 +148,16 @@ class PartsListTaskDialog:
                 ],
             border_width = form.doubleSpinBox_lineWidth.value(),
             border_color='rgb(0,0,0)',
-            padding_x = form.doubleSpinBox_padding.value(), 
-            padding_y = form.doubleSpinBox_padding.value(), 
+            padding_x = form.doubleSpinBox_padding.value(),
+            padding_y = form.doubleSpinBox_padding.value(),
             extra_rows= 0,
             textRenderer_table = SvgTextRenderer(
-                u'inherit', 
-                u'%1.2f pt' % form.doubleSpinBox_fontSize.value(), 
-                form.lineEdit_fontColor.text() 
+                u'inherit',
+                u'%1.2f pt' % form.doubleSpinBox_fontSize.value(),
+                form.lineEdit_fontColor.text()
                 )
             )
-    
+
     def update_directoryFilter(self, *args):
         try:
             del d.partsList.directoryMask[:]
@@ -174,7 +174,6 @@ class PartsListTaskDialog:
     def reject(self):
         previewDimension.removePreviewGraphicItems( recomputeActiveDocument = True )
         FreeCADGui.Control.closeDialog()
-        
+
     def getStandardButtons(self): #http://forum.freecadweb.org/viewtopic.php?f=10&t=11801
         return 0x00400000
-

--- a/planeConstraint.py
+++ b/planeConstraint.py
@@ -17,7 +17,7 @@ class PlaneSelectionGate2:
 def promt_user_for_axis_for_constraint_label():
      preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Assembly2")
      return preferences.GetBool('promtUserForAxisConstraintLabel', False)
-     
+
 
 def parseSelection(selection, objectToUpdate=None):
      validSelection = False
@@ -33,16 +33,16 @@ def parseSelection(selection, objectToUpdate=None):
      if not validSelection:
           msg = '''Plane constraint requires a selection of either
 - 2 planes, or
-- 1 plane and 1 vertex 
+- 1 plane and 1 vertex
 
 Selection made:
 %s'''  % printSelection(selection)
-          QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", msg)
-          return 
+          QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", msg)
+          return
 
      if objectToUpdate is None:
           if promt_user_for_axis_for_constraint_label():
-               extraText, extraOk = QtGui.QInputDialog.getText(QtGui.qApp.activeWindow(), "Axis", "Axis for constraint Label", QtGui.QLineEdit.Normal, "0")
+               extraText, extraOk = QtGui.QInputDialog.getText(QtGui.QApplication.activeWindow(), "Axis", "Axis for constraint Label", QtGui.QLineEdit.Normal, "0")
                if not extraOk:
                     return
           else:
@@ -56,15 +56,15 @@ Selection made:
           c.addProperty("App::PropertyString","Object2","ConstraintInfo").Object2 = cParms[1][0]
           c.addProperty("App::PropertyString","SubElement2","ConstraintInfo").SubElement2 = cParms[1][1]
           c.addProperty('App::PropertyDistance','offset',"ConstraintInfo")
-     
+
           c.addProperty("App::PropertyEnumeration","directionConstraint", "ConstraintInfo")
           c.directionConstraint = ["none","aligned","opposed"]
 
           c.setEditorMode('Type',1)
           for prop in ["Object1","Object2","SubElement1","SubElement2"]:
-               c.setEditorMode(prop, 1) 
+               c.setEditorMode(prop, 1)
           c.Proxy = ConstraintObjectProxy()
-          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/planeConstraint.svg', True, cParms[1][2], cParms[0][2], extraText) 
+          c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/planeConstraint.svg', True, cParms[1][2], cParms[0][2], extraText)
      else:
           debugPrint(2, "redefining %s" % objectToUpdate.Name )
           c = objectToUpdate
@@ -72,11 +72,11 @@ Selection made:
           c.SubElement1 = cParms[0][1]
           c.Object2 = cParms[1][0]
           c.SubElement2 = cParms[1][1]
-          updateObjectProperties(c)          
+          updateObjectProperties(c)
      constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
      with open(constraintFile, 'w') as outfile:
-          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')        
-          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')        
+          outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')
+          outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')
      constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
      #print constraints
      if len(constraints) > 0:
@@ -89,7 +89,7 @@ Selection made:
      c.purgeTouched()
      c.Proxy.callSolveConstraints()
      repair_tree_view()
-         
+
 
 selection_text = '''Selection 1 options:
   - plane
@@ -105,20 +105,20 @@ class PlaneConstraintCommand:
                parseSelection( selection )
           else:
                FreeCADGui.Selection.clearSelection()
-               ConstraintSelectionObserver( 
-                    PlaneSelectionGate(), 
-                    parseSelection, 
-                    taskDialog_title ='add plane constraint', 
-                    taskDialog_iconPath = self.GetResources()['Pixmap'], 
+               ConstraintSelectionObserver(
+                    PlaneSelectionGate(),
+                    parseSelection,
+                    taskDialog_title ='add plane constraint',
+                    taskDialog_iconPath = self.GetResources()['Pixmap'],
                     taskDialog_text = selection_text,
                     secondSelectionGate = PlaneSelectionGate2() )
-               
-     def GetResources(self): 
+
+     def GetResources(self):
           return {
-               'Pixmap' : ':/assembly2/icons/planeConstraint.svg', 
-               'MenuText': 'Add plane constraint', 
+               'Pixmap' : ':/assembly2/icons/planeConstraint.svg',
+               'MenuText': 'Add plane constraint',
                'ToolTip': 'Add a plane constraint between two objects'
-               } 
+               }
 
 FreeCADGui.addCommand('addPlaneConstraint', PlaneConstraintCommand())
 
@@ -128,17 +128,17 @@ class RedefineConstraintCommand:
         self.constObject = FreeCADGui.Selection.getSelectionEx()[0].Object
         debugPrint(3,'redefining %s' % self.constObject.Name)
         FreeCADGui.Selection.clearSelection()
-        ConstraintSelectionObserver( 
-                    PlaneSelectionGate(), 
-                    self.UpdateConstraint, 
-                    taskDialog_title ='add plane constraint', 
-                    taskDialog_iconPath = ':/assembly2/icons/planeConstraint.svg', 
+        ConstraintSelectionObserver(
+                    PlaneSelectionGate(),
+                    self.UpdateConstraint,
+                    taskDialog_title ='add plane constraint',
+                    taskDialog_iconPath = ':/assembly2/icons/planeConstraint.svg',
                     taskDialog_text = selection_text,
                     secondSelectionGate = PlaneSelectionGate2() )
 
     def UpdateConstraint(self, selection):
         parseSelection( selection, self.constObject)
 
-    def GetResources(self): 
-        return { 'MenuText': 'Redefine' } 
+    def GetResources(self):
+        return { 'MenuText': 'Redefine' }
 FreeCADGui.addCommand('redefinePlaneConstraint', RedefineConstraintCommand())

--- a/sphericalSurfaceConstraint.py
+++ b/sphericalSurfaceConstraint.py
@@ -31,24 +31,24 @@ def parseSelection(selection, objectToUpdate=None):
     if not validSelection:
           msg = '''To add a spherical surface constraint select two spherical surfaces (or vertexs), each from a different part. Selection made:
 %s'''  % printSelection(selection)
-          QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Incorrect Usage", msg)
-          return 
+          QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Incorrect Usage", msg)
+          return
 
     if objectToUpdate == None:
         cName = findUnusedObjectName('sphericalSurfaceConstraint')
         debugPrint(2, "creating %s" % cName )
         c = FreeCAD.ActiveDocument.addObject("App::FeaturePython", cName)
-                
+
         c.addProperty("App::PropertyString","Type","ConstraintInfo").Type = 'sphericalSurface'
         c.addProperty("App::PropertyString","Object1","ConstraintInfo").Object1 = cParms[0][0]
         c.addProperty("App::PropertyString","SubElement1","ConstraintInfo").SubElement1 = cParms[0][1]
         c.addProperty("App::PropertyString","Object2","ConstraintInfo").Object2 = cParms[1][0]
         c.addProperty("App::PropertyString","SubElement2","ConstraintInfo").SubElement2 = cParms[1][1]
-    
+
         c.setEditorMode('Type',1)
         for prop in ["Object1","Object2","SubElement1","SubElement2"]:
-            c.setEditorMode(prop, 1) 
-        
+            c.setEditorMode(prop, 1)
+
         c.Proxy = ConstraintObjectProxy()
         c.ViewObject.Proxy = ConstraintViewProviderProxy( c, ':/assembly2/icons/sphericalSurfaceConstraint.svg', True, cParms[1][2], cParms[0][2])
     else:
@@ -61,8 +61,8 @@ def parseSelection(selection, objectToUpdate=None):
         updateObjectProperties(c)
     constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
     with open(constraintFile, 'w') as outfile:
-         outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')        
-         outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')        
+         outfile.write(make_string(s1.ObjectName)+'\n'+str(s1.Object.Placement.Base)+'\n'+str(s1.Object.Placement.Rotation)+'\n')
+         outfile.write(make_string(s2.ObjectName)+'\n'+str(s2.Object.Placement.Base)+'\n'+str(s2.Object.Placement.Rotation)+'\n')
     constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
     #print constraints
     if len(constraints) > 0:
@@ -73,9 +73,9 @@ def parseSelection(selection, objectToUpdate=None):
                  outfile.write(make_string(lastConstraintAdded.Name)+'\n')
 
     c.purgeTouched()
-    c.Proxy.callSolveConstraints()    
+    c.Proxy.callSolveConstraints()
     repair_tree_view()
-    
+
 selection_text = '''Selection options:
   - spherical surface
   - vertex'''
@@ -88,20 +88,20 @@ class SphericalSurfaceConstraintCommand:
             parseSelection( selection )
         else:
             FreeCADGui.Selection.clearSelection()
-            ConstraintSelectionObserver( 
-                SphericalSurfaceSelectionGate(), 
+            ConstraintSelectionObserver(
+                SphericalSurfaceSelectionGate(),
                 parseSelection,
-                taskDialog_title ='add spherical surface constraint', 
-                taskDialog_iconPath = self.GetResources()['Pixmap'], 
+                taskDialog_title ='add spherical surface constraint',
+                taskDialog_iconPath = self.GetResources()['Pixmap'],
                 taskDialog_text = selection_text
                 )
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : ':/assembly2/icons/sphericalSurfaceConstraint.svg', 
-            'MenuText': 'Add a spherical surface constraint', 
+            'Pixmap' : ':/assembly2/icons/sphericalSurfaceConstraint.svg',
+            'MenuText': 'Add a spherical surface constraint',
             'ToolTip': 'Add a spherical surface constraint between two objects'
-            } 
+            }
 
 FreeCADGui.addCommand('addSphericalSurfaceConstraint', SphericalSurfaceConstraintCommand())
 
@@ -111,16 +111,16 @@ class RedefineSphericalSurfaceConstraintCommand:
         self.constObject = FreeCADGui.Selection.getSelectionEx()[0].Object
         debugPrint(3,'redefining %s' % self.constObject.Name)
         FreeCADGui.Selection.clearSelection()
-        ConstraintSelectionObserver( 
-            SphericalSurfaceSelectionGate(), 
+        ConstraintSelectionObserver(
+            SphericalSurfaceSelectionGate(),
             self.UpdateConstraint,
-            taskDialog_title ='redefine spherical surface constraint', 
-            taskDialog_iconPath = ':/assembly2/icons/sphericalSurfaceConstraint.svg', 
+            taskDialog_title ='redefine spherical surface constraint',
+            taskDialog_iconPath = ':/assembly2/icons/sphericalSurfaceConstraint.svg',
             taskDialog_text = selection_text
             )
     def UpdateConstraint(self, selection):
         parseSelection( selection, self.constObject)
 
-    def GetResources(self): 
-        return { 'MenuText': 'Redefine' } 
+    def GetResources(self):
+        return { 'MenuText': 'Redefine' }
 FreeCADGui.addCommand('redefineSphericalSurfaceConstraint', RedefineSphericalSurfaceConstraintCommand())

--- a/undo.py
+++ b/undo.py
@@ -15,7 +15,7 @@ class UndoConstraint:
     def Activated(self):
         constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
         if len(constraints) == 0:
-            QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Undo aborted since no assembly2 constraints in active document.')
+            QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Undo aborted since no assembly2 constraints in active document.')
             return
         lastConstraintAdded = constraints[-1]
         #print lastConstraintAdded.Name
@@ -54,7 +54,7 @@ class UndoConstraint:
                 FreeCAD.ActiveDocument.getObject(s_nm[1]).Placement.Rotation = FreeCAD.Rotation (s_plcR[1][0],s_plcR[1][1],s_plcR[1][2],s_plcR[1][3])  #App.Vector (5.000000000000001, 5.000000000000003, 5.00)
             constraints = [ obj for obj in FreeCAD.ActiveDocument.Objects if 'ConstraintInfo' in obj.Content ]
             if len(constraints) == 0:
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Command Aborted", 'Flip aborted since no assembly2 constraints in active document.')
+                QtGui.QMessageBox.information(  QtGui.QApplication.activeWindow(), "Command Aborted", 'Flip aborted since no assembly2 constraints in active document.')
                 return
             lastConstraintAdded = constraints[-1]
             if undo_constraint == lastConstraintAdded.Name:
@@ -64,7 +64,7 @@ class UndoConstraint:
             FreeCAD.ActiveDocument.recompute()
             os.remove(constraintFile)
         return
-        
+
     def IsActive(self):
         constraintFile = os.path.join( GuiPath , 'constraintFile.txt')
         if not os.path.exists(constraintFile):
@@ -73,7 +73,7 @@ class UndoConstraint:
 
     def GetResources(self):
         return {
-            'Pixmap' : os.path.join( iconPath , 'EditUndo.svg'), 
+            'Pixmap' : os.path.join( iconPath , 'EditUndo.svg'),
             'MenuText': 'Undo last Constrain',
             'ToolTip': 'Undo last Constrain'
             }

--- a/viewProviderProxies.py
+++ b/viewProviderProxies.py
@@ -8,9 +8,9 @@ def group_constraints_under_parts():
 
 def allow_deletetion_when_activice_doc_ne_object_doc():
     parms = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Assembly2")
-    return parms.GetBool('allowDeletetionFromExternalDocuments', False) 
+    return parms.GetBool('allowDeletetionFromExternalDocuments', False)
 
-class ImportedPartViewProviderProxy:   
+class ImportedPartViewProviderProxy:
     def onDelete(self, viewObject, subelements): # subelements is a tuple of strings
         if not allow_deletetion_when_activice_doc_ne_object_doc() and FreeCAD.activeDocument() != viewObject.Object.Document:
             FreeCAD.Console.PrintMessage("preventing deletetion of %s since active document != %s. Disable behavior in assembly2 preferences.\n" % (viewObject.Object.Label, viewObject.Object.Document.Name) )
@@ -27,7 +27,7 @@ class ImportedPartViewProviderProxy:
             #FreeCAD.Console.PrintMessage("  delete list %s\n" % str(deleteList) )
             for c in deleteList:
                 #FreeCAD.Console.PrintMessage("  - removing constraint %s\n" % c.Name )
-                if hasattr( c.Proxy, 'mirrorName'): # then also deleter constraints mirror 
+                if hasattr( c.Proxy, 'mirrorName'): # then also deleter constraints mirror
                     doc.removeObject( c.Proxy.mirrorName )
                 doc.removeObject(c.Name)
         return True # If False is returned the object won't be deleted
@@ -37,7 +37,7 @@ class ImportedPartViewProviderProxy:
 
     def __setstate__(self, state):
         return None
-    
+
     def attach(self, vobj):
         self.object_Name = vobj.Object.Name
         #self.ViewObject = vobj
@@ -61,7 +61,7 @@ class ImportedPartViewProviderProxy:
         or something like that ...
         '''
 
-        
+
         children = []
         if hasattr(self, 'Object'):
             importedPart = self.Object
@@ -132,10 +132,10 @@ class ConstraintViewProviderProxy:
             if hasattr( getattr(part1.ViewObject,'Proxy',None),'claimChildren') \
                or hasattr( getattr(part2.ViewObject,'Proxy',None),'claimChildren'):
                 self.mirror_name = create_constraint_mirror(  constraintObj, iconPath, origLabel, mirrorLabel, extraLabel )
-        
+
     def getIcon(self):
         return self.iconPath
-        
+
     def attach(self, vobj): #attach to what document?
         vobj.addDisplayMode( coin.SoGroup(),"Standard" )
 
@@ -157,7 +157,7 @@ class ConstraintViewProviderProxy:
         doc = obj.Document
         if isinstance( obj.Proxy, ConstraintMirrorObjectProxy ):
             doc.removeObject(  obj.Proxy.constraintObj_name ) # also delete the original constraint which obj mirrors
-        elif hasattr( obj.Proxy, 'mirror_name'): # the original constraint, #isinstance( obj.Proxy,  ConstraintObjectProxy ) not done since ConstraintObjectProxy not defined in namespace 
+        elif hasattr( obj.Proxy, 'mirror_name'): # the original constraint, #isinstance( obj.Proxy,  ConstraintObjectProxy ) not done since ConstraintObjectProxy not defined in namespace
             doc.removeObject( obj.Proxy.mirror_name ) # also delete mirror
         return True
 
@@ -213,7 +213,7 @@ class ConstraintMirrorObjectProxy:
         constraintObj.Proxy.mirror_name = obj.Name
         self.disable_onChanged = False
         obj.Proxy = self
-        
+
     def execute(self, obj):
         return #no work required in onChanged causes touched in original constraint ...
 
@@ -224,7 +224,7 @@ class ConstraintMirrorObjectProxy:
         '''
         #FreeCAD.Console.PrintMessage("%s.%s property changed\n" % (obj.Name, prop))
         if getattr( self, 'disable_onChanged', True):
-            return 
+            return
         if obj.getGroupOfProperty( prop ) == 'ConstraintNfo':
             if hasattr( self, 'constraintObj_name' ):
                 constraintObj = obj.Document.getObject( self.constraintObj_name )
@@ -243,9 +243,9 @@ def repair_tree_view():
             if isinstance(c,QtGui.QTreeView) and isinstance(c, QtGui.QTreeWidget):
                 matches.append(c)
             search_children_recursively( c)
-    search_children_recursively(QtGui.qApp.activeWindow())
+    search_children_recursively(QtGui.QApplication.activeWindow())
     for m in matches:
-        tree_nodes =  get_treeview_nodes(m) 
+        tree_nodes =  get_treeview_nodes(m)
         def get_node_by_label( label ):
             if label in tree_nodes and len( tree_nodes[label] ) == 1:
                 return tree_nodes[label][0]
@@ -266,7 +266,7 @@ def repair_tree_view():
                                 FreeCAD.Console.PrintMessage('repair_tree_view: %s.ViewObject.Proxy.Object = %s' % (imported_obj.Name, imported_obj.Name) )
                             for constraint_obj in imported_obj.ViewObject.Proxy.claimChildren():
                                 #FreeCAD.Console.PrintMessage('  - %s\n' % constraint_obj.Label )
-                                if get_node_by_label( constraint_obj.Label ): 
+                                if get_node_by_label( constraint_obj.Label ):
                                     #FreeCAD.Console.PrintMessage('     (found treeview node)\n')
                                     node_constraint_obj = get_node_by_label( constraint_obj.Label )
                                     if id( node_constraint_obj.parent()) != id(node_imported_obj):
@@ -292,4 +292,3 @@ def get_treeview_nodes( treeWidget ):
             walk( node.child( i ) )
     walk( treeWidget.itemAt(0,0) )
     return tree_nodes
-


### PR DESCRIPTION
….activeWindow()

and removed training white space. Compatible with current FreeCad 0.17 build.

I have checked these changes on my system:
OS: Mac OS X
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.17.13519 (Git)
Build type: Release
Branch: (HEAD detached at 1a8b868)
Hash: 1a8b868018f45ea486c0023fdbfeb06febc1fb89
Python version: 2.7.14
Qt version: 5.10.1
Coin version: 4.0.0a
OCC version: 7.2.0
Locale: English/UnitedKingdom (en_GB)

And all seems well - but I am not and experienced Assembly2 user so please test.
