### PR TITLE
Fix importPart. Refresh imported parts fail when there is no Shape

### DIFF
--- a/assembly2/utils/muxAssembly.py
+++ b/assembly2/utils/muxAssembly.py
@@ -18,7 +18,8 @@ def muxObjects(doc, mode=0):
     for obj in objects:
         if 'importPart' in obj.Content:
             debugPrint(3, '  - parsing "%s"' % (obj.Name))
-            faces = faces + obj.Shape.Faces
+            if hasattr(obj, 'Shape'):
+                faces = faces + obj.Shape.Faces
     return Part.makeShell(faces)
 
 def muxMapColors(doc, muxedObj, mode=0):
@@ -32,7 +33,7 @@ def muxMapColors(doc, muxedObj, mode=0):
         objects = doc.Objects
 
     for obj in objects:
-        if 'importPart' in obj.Content:
+        if 'importPart' in obj.Content and hasattr(obj, 'Shape'):
             for i, face in enumerate(obj.Shape.Faces):
                 if i < len(obj.ViewObject.DiffuseColor):
                     clr = obj.ViewObject.DiffuseColor[i]


### PR DESCRIPTION
1. I have created two parts from imported SVG files.
2. Then I have created an assembly importing that two parts.
3. Then I have modified the original part files.
4. Then when I click on "Update parts imported into the assembly", the script fails:

```
Running the Python command 'assembly2_updateImportedPartsCommand' failed:
Traceback (most recent call last):
  File "/home/u/.FreeCAD/Mod/assembly2/assembly2/importPart/__init__.py", line 230, in Activated
    importPart( obj.sourceFile, obj.Name,  doc_assembly )
  File "/home/u/.FreeCAD/Mod/assembly2/assembly2/importPart/__init__.py", line 59, in importPart
    obj_to_copy.Shape =  muxObjects(doc)
  File "/home/u/.FreeCAD/Mod/assembly2/assembly2/utils/muxAssembly.py", line 21, in muxObjects
    faces = faces + obj.Shape.Faces

Fcstd_Property_List instance has no attribute 'Shape'
```
So I have edited the muxAssembly.py adding two simple checks. It works.
