### PR TITLE
fixed the typo dectected. also in the older versions, importPart could not open the file dialog

### DIFF
--- a/checkAssembly.py
+++ b/checkAssembly.py
@@ -53,7 +53,7 @@ class CheckAssemblyCommand:
                 FreeCAD.Console.PrintError( message + '\n' )
                 response = QtGui.QMessageBox.critical(QtGui.qApp.activeWindow(), "Assembly Check", message + errorMsg)#, flags)
             else:
-                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Assembly Check", "Passed:\n  - No overlap/interferance dectected." + errorMsg)
+                QtGui.QMessageBox.information(  QtGui.qApp.activeWindow(), "Assembly Check", "Passed:\n  - No overlap/interferance detected." + errorMsg)
     def GetResources(self): 
         msg = 'Check assembly for part overlap/interferance'
         return {

--- a/importPart.py
+++ b/importPart.py
@@ -134,7 +134,7 @@ class ImportPartCommand:
         #    "FreeCAD Document (*.fcstd)"
         #    )
         dialog = QtGui.QFileDialog(
-            QtGui.qApp.activeWindow(),
+            QtGui.QApplication.activeWindow(),
             "Select FreeCAD document to import part from"
             )
         dialog.setNameFilter("Supported Formats (*.FCStd *.brep *.brp *.imp *.iges *.igs *.obj *.step *.stp);;All files (*.*)")


### PR DESCRIPTION
The first fix in checkAssembly.py just fixes the typo "dectected" that comes up after you check the assembly:
<img width="447" alt="dect" src="https://user-images.githubusercontent.com/7983542/48309557-ec92c500-e531-11e8-8a74-f4b7fab3bbda.png">

So this should be an easy decision to merge it. 

The second fix in "importPart.py" may no longer be relevant since i think you changed this file signifcantly. However you may evaluate it and decide. 
