### PR TITLE
Fix Icon path discovery on macOS X

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -77,6 +77,11 @@ class Assembly2Workbench (Workbench):
                       'assembly2_randomColorAll']
                     )
 
-    Icon = ':/assembly2/icons/workBenchIcon.svg'
+    import assembly2_locator
+    import os
+    assembly2_path = os.path.dirname(assembly2_locator.__file__)
+    assembly2_icons_path =  os.path.join( assembly2_path, 'Gui', 'Resources', 'icons')
+
+    Icon = os.path.join( assembly2_icons_path , 'workBenchIcon.svg')
 
 Gui.addWorkbench( Assembly2Workbench() )

--- a/assembly2_locator
+++ b/assembly2_locator
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+###################################################################################
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+###################################################################################


### PR DESCRIPTION
There is a slight error on MacOS X startup, as the icon path is not properly discovered. This is fixing it.